### PR TITLE
Update waka-readme.yml

### DIFF
--- a/.github/workflows/waka-readme.yml
+++ b/.github/workflows/waka-readme.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-readme:
     name: WakaReadme DevMetrics
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: athul/waka-readme@master # this action name
         with:


### PR DESCRIPTION
fixes error uccured in the workflows, by Switch back to Ubuntu 22 by changing workflow YAML to `use runs-on: ubuntu-22.04` We support two latest LTS Ubuntu versions, so Ubuntu 22 will still be maintained for the next 2 years.
see [here](https://github.com/actions/runner-images/issues/10636)